### PR TITLE
allow pkgslog to accept lower levels than its wrapped handler

### DIFF
--- a/pkgslog_test.go
+++ b/pkgslog_test.go
@@ -3,12 +3,12 @@ package pkgslog_test
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
-	"testing"
-
 	"log/slog"
-
+	"slices"
+	"testing"
 	"testing/slogtest"
 
 	"github.com/reugn/pkgslog"
@@ -52,16 +52,118 @@ func TestPkgSlog(t *testing.T) {
 	}
 }
 
+func TestPkgSlogOverrideUpstreamHandlerLogLevel(t *testing.T) { //nolint:funlen
+	levels := []slog.Level{
+		slog.LevelDebug,
+		slog.LevelError,
+		slog.LevelInfo,
+		slog.LevelWarn,
+	}
+
+	tests := []struct {
+		name         string
+		pkgLevel     slog.Level
+		handlerLevel slog.Level
+		enabled      []slog.Level
+		disabled     []slog.Level
+	}{
+		// If
+		// 		"pkgslog" level is set to DEBUG
+		// 		"handler" level is set to WARNING
+		// Then
+		// 		"pkgslog" should accept log levels appropriate
+		// 		to its *minimum* configured log level
+		// Meaning
+		// 		All log levels should be accepted
+		{
+			name:         "debug level",
+			pkgLevel:     slog.LevelDebug,
+			handlerLevel: slog.LevelWarn,
+			enabled: []slog.Level{
+				slog.LevelDebug,
+				slog.LevelError,
+				slog.LevelInfo,
+				slog.LevelWarn,
+			},
+			disabled: []slog.Level{},
+		},
+		// If
+		// 		"pkgslog" level is set to INFO
+		// 		"handler" level is set to WARNING
+		// Then
+		// 		"pkgslog" should accept log levels appropriate
+		// 		to its *minimum* configured log level
+		// Meaning
+		// 		DEBUG level should be rejected
+		//		All other levels should be accepted
+		{
+			name:         "info level",
+			pkgLevel:     slog.LevelInfo,
+			handlerLevel: slog.LevelWarn,
+			enabled: []slog.Level{
+				slog.LevelError,
+				slog.LevelInfo,
+				slog.LevelWarn,
+			},
+			disabled: []slog.Level{
+				slog.LevelDebug,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			writer := bufio.NewWriter(&buf)
+
+			textHandler := slog.NewJSONHandler(
+				writer,
+				&slog.HandlerOptions{
+					Level: tt.handlerLevel,
+				},
+			)
+
+			packageMap := map[string]slog.Level{
+				"github.com/reugn/pkgslog": tt.pkgLevel,
+			}
+
+			logger := pkgslog.NewPackageHandler(textHandler, packageMap)
+			for _, checkLevel := range levels {
+				if logger.Enabled(context.TODO(), checkLevel) {
+					if !slices.Contains(tt.enabled, checkLevel) {
+						t.Fatal("expected " + checkLevel.String() + " level to be DISABLED")
+					}
+
+					continue
+				}
+
+				if !slices.Contains(tt.disabled, checkLevel) {
+					t.Fatal("expected " + checkLevel.String() + " level to be DISABLED")
+				}
+			}
+		})
+	}
+}
+
 func parseLogEntries(t *testing.T, output []byte) []map[string]any {
-	var entries []map[string]any
-	lines := bytes.Split(output, []byte("\n"))
+	var (
+		entries []map[string]any
+		lines   = bytes.Split(output, []byte("\n"))
+	)
+
 	for i := 0; i < len(lines)-1; i++ { // last one is empty
 		line := lines[i]
+
 		var entry map[string]any
 		if err := json.Unmarshal(line, &entry); err != nil {
 			t.Error(err)
 		}
+
 		entries = append(entries, entry)
 	}
+
 	return entries
 }


### PR DESCRIPTION
Currently the minimum log level is controlled by the wrapped handler

This change makes the pkgslog handler accept any log level (or lower) configured  for a package level.

This mean you can now have your wrapped log handler at `WARN` but turn on `DEBUG` level for a specific package and stil have those debug level messages be printed.

In my use-case, I'm using [`slog-multi`](github.com/samber/slog-multi) and a couple of other wrapped handlers like the example below, and I want to be able to adjust log level per package.

```go
slog.New(
	slogmulti.
		Pipe(
			func(next slog.Handler) slog.Handler {
				return pkgslog.NewPackageHandler(next, packageLogLevels())
			},
		).
		Pipe(
			slogctx.NewMiddleware(&slogctx.HandlerOptions{}),
		).
		Pipe(
			slogdedup.NewOverwriteMiddleware(&slogdedup.OverwriteHandlerOptions{
				ResolveBuiltinKeyConflict: slogdedup.KeepIfBuiltinKeyConflict,
			}),
		).
		Handler(
			logHandler(stderr),
		),
)
```

I'm controlling my log levels like this, where each package level can be controlled via ENV variables, overriding the `global` log level

```go
func pkgLogLevel(name string, fallback slog.Level) slog.Level {
	return ParseLogLevel(os.Getenv(name+"_LOG_LEVEL"), fallback)
}

func packageLogLevels() map[string]slog.Level {
	return map[string]slog.Level{
		pkgPrefix + "/pkg/parser":  pkgLogLevel("PARSER", slog.LevelWarn),
		pkgPrefix + "/pkg/scanner": pkgLogLevel("SCANNER", slog.LevelWarn),
	}
}
```